### PR TITLE
Add rfc6901 implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ dist: xenial
 language: go
 
 go:
-- "1.11.4"
-- "1.x"
+- "1.13"
 
 env:
 - GO111MODULE=on

--- a/json_pointer_test.go
+++ b/json_pointer_test.go
@@ -1,0 +1,85 @@
+package jmap
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestJSONPointer(t *testing.T) {
+	document := `   {
+		"foo": ["bar", "baz"],
+		"": 0,
+		"a/b": 1,
+		"c%d": 2,
+		"e^f": 3,
+		"g|h": 4,
+		"i\\j": 5,
+		"k\"l": 6,
+		" ": 7,
+		"m~n": 8
+	 }`
+
+	t.Run("map", func(ts *testing.T) {
+		sample := []struct {
+			path   string
+			expect interface{}
+		}{
+			{path: "/foo", expect: []interface{}{"bar", "baz"}},
+			{path: "/foo/0", expect: "bar"},
+			{path: "/", expect: float64(0)},
+			{path: "/a~1b", expect: float64(1)},
+			{path: "/c%d", expect: float64(2)},
+			{path: "/e^f", expect: float64(3)},
+			{path: "/g|h", expect: float64(4)},
+			{path: "/g|h", expect: float64(4)},
+			{path: "/i\\j", expect: float64(5)},
+			{path: "/k\"l", expect: float64(6)},
+			{path: "/ ", expect: float64(7)},
+			{path: "/m~0n", expect: float64(8)},
+		}
+		var o map[string]interface{}
+		err := json.Unmarshal([]byte(document), &o)
+		if err != nil {
+			ts.Fatal(err)
+		}
+		for _, v := range sample {
+			r, err := GetJSON(v.path, o)
+			if err != nil {
+				ts.Error(v.path, err)
+				continue
+			}
+			if !reflect.DeepEqual(r, v.expect) {
+				t.Errorf("%s : expected %T got %T %#v %#v", v.path, v.expect, r, v.expect, r)
+			}
+		}
+	})
+	t.Run("struct", func(ts *testing.T) {
+		sample := []struct {
+			path   string
+			expect interface{}
+		}{
+			{path: "/foo", expect: []interface{}{"bar", "baz"}},
+			{path: "/foo/0", expect: "bar"},
+			{path: "/a~1b", expect: float64(1)},
+		}
+		var o = struct {
+			F1 []interface{} `json:"foo"`
+			F2 float64       `json:"a/b"`
+		}{}
+		err := json.Unmarshal([]byte(document), &o)
+		if err != nil {
+			ts.Fatal(err)
+		}
+		for _, v := range sample {
+			r, err := GetJSON(v.path, o)
+			if err != nil {
+				ts.Error(v.path, err)
+				continue
+			}
+			if !reflect.DeepEqual(r, v.expect) {
+				t.Errorf("%s : expected %T got %T %#v %#v", v.path, v.expect, r, v.expect, r)
+			}
+		}
+	})
+}

--- a/json_ponter.go
+++ b/json_ponter.go
@@ -1,0 +1,121 @@
+package jmap
+
+import (
+	"errors"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+var jsonPtrRegexp = regexp.MustCompile(`(/(([^/~])|(~[01]))*)`)
+
+// ErrInvalidPointerSyntax is returned when the json pointer syntax does not
+// conform to https://tools.ietf.org/html/rfc6901#page-2
+var ErrInvalidPointerSyntax = errors.New("invalid json pointer syntax")
+
+// ErrNoPointerValue is returned when there is no value found on the json ponter
+// path.
+var ErrNoPointerValue = errors.New("no pointer value")
+
+// JSONObject is an interface for retrieving object properties based on string
+// keys
+type JSONObject interface {
+	Get(key string) JSONObject
+	Interface() interface{}
+}
+
+type jsonPtrWrapper struct {
+	value reflect.Value
+}
+
+func (j *jsonPtrWrapper) Interface() interface{} {
+	return j.value.Interface()
+}
+
+func (j *jsonPtrWrapper) Get(key string) JSONObject {
+	v := j.value
+	if v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
+	for v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	switch v.Kind() {
+	case reflect.Map:
+		r := v.MapRange()
+		for r.Next() {
+			k := r.Key()
+			v := r.Value()
+			if k.String() == key {
+				return &jsonPtrWrapper{value: v}
+			}
+		}
+	case reflect.Slice:
+		i, err := strconv.Atoi(key)
+		if err != nil {
+			return nil
+		}
+		if i >= v.Len() {
+			// out of range
+			return nil
+		}
+		return &jsonPtrWrapper{value: v.Index(i)}
+	case reflect.Struct:
+		typ := v.Type()
+		for i := 0; i < typ.NumField(); i++ {
+			f := typ.Field(i)
+			ch, _ := utf8.DecodeRuneInString(f.Name)
+			if !unicode.IsUpper(ch) {
+				continue
+			}
+			if f.Name == key {
+				return &jsonPtrWrapper{value: v.Field(i)}
+			}
+			tag := f.Tag.Get("json")
+			if tag != "" {
+				tag = strings.Split(tag, ",")[0]
+				if tag == key {
+					return &jsonPtrWrapper{value: v.Field(i)}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// GetJSON uses rfc6901 to return object from path which is a json pointer
+// string syntax.
+//
+// object can either be a struct/array/map. It is possible to pass anything that
+// implements JSONObject interface as object.
+func GetJSON(path string, object interface{}) (interface{}, error) {
+	if !jsonPtrRegexp.Match([]byte(path)) {
+		return nil, ErrInvalidPointerSyntax
+	}
+	var o JSONObject
+	if x, ok := object.(JSONObject); ok {
+		o = x
+	} else {
+		o = &jsonPtrWrapper{value: reflect.ValueOf(object)}
+	}
+
+	parts := jsonPtrRegexp.FindAllString(path, -1)
+	for _, p := range parts {
+		if o == nil {
+			return nil, ErrNoPointerValue
+		}
+		p = strings.Replace(p, "~1", "/", -1)
+		p = strings.Replace(p, "~0", "~", -1)
+		if p[0] == '/' {
+			p = p[1:]
+		}
+		o = o.Get(p)
+	}
+	if o == nil {
+		return nil, ErrNoPointerValue
+	}
+	return o.Interface(), nil
+}


### PR DESCRIPTION
[RFC6901](https://tools.ietf.org/html/rfc6901)

This is used  when referencing previous method results
https://tools.ietf.org/html/draft-ietf-jmap-core-17#section-3.6

***OFFTOPIC*** : I just discovered this project today, I have been working on jmap go implementation too.I was more focused on the server, I see you focused more on the client. I will try go integrate my server code into this, I don't think its necessary to duplicate effort.